### PR TITLE
docs: Day9 home file count update by cprein19

### DIFF
--- a/Day9_File_Counts.md
+++ b/Day9_File_Counts.md
@@ -12,7 +12,7 @@ the following table.
 | cslinuxlab-04 |                 |
 | cslinuxlab-05 |                 |
 | cslinuxlab-06 |                 |
-| cslinuxlab-07 |                 |
+| cslinuxlab-07 | 1106588         |
 | cslinuxlab-08 | 12057           |
 | cslinuxlab-09 |                 |
 | cslinuxlab-10 |                 |


### PR DESCRIPTION
Update Day9_File_Counts.md to contain file count for cprein19's personal machine. To find the number of files in the home directory, cprein19 used the 'find ~ | wc -l'

I think you will find this addition to our class notes most satisfactory.


